### PR TITLE
Added task queue to delay individual indexing by 5 seconds

### DIFF
--- a/DataModels.py
+++ b/DataModels.py
@@ -2,7 +2,7 @@ import logging, json
 from decimal import *
 
 #App Engine platform
-from google.appengine.api import mail, memcache, datastore_errors
+from google.appengine.api import mail, memcache, datastore_errors, taskqueue
 from google.appengine.ext import ndb, blobstore
 
 #Search
@@ -475,8 +475,8 @@ class Individual(ndb.Expando):
             memcache.delete("teammembers" + t.team.urlsafe())
             memcache.delete("teammembersdict" + t.team.urlsafe())
             memcache.delete("info" + t.team.urlsafe() + e.websafe)
-
-        e.search.index()
+            
+        taskqueue.add(url="/tasks/delayindexing", params={'e' : e.websafe}, countdown=5, queue_name="delayindexing")
 
     ## -- Before Delete -- ##
     @classmethod

--- a/queue.yaml
+++ b/queue.yaml
@@ -22,3 +22,9 @@ queue:
   retry_parameters:
     min_backoff_seconds: 30
     max_backoff_seconds: 300
+
+- name: delayindexing
+  rate: 1/s
+  retry_parameters:
+    min_backoff_seconds: 30
+    max_backoff_seconds: 300

--- a/tasks.py
+++ b/tasks.py
@@ -91,10 +91,18 @@ class IndexAll(webapp2.RequestHandler):
             for t in teams:
                 t.search.index()
 
+class DelayIndexing(webapp2.RequestHandler):
+    def post(self):
+        entity_key = self.request.get("e")
+
+        e = tools.getKey(entity_key).get()
+        e.search.index()
+
 app = webapp2.WSGIApplication([
        ('/tasks/confirmation', Confirmation),
        ('/tasks/annualreport', AnnualReport),
        ('/tasks/indexall', IndexAll),
+       ('/tasks/delayindexing', DelayIndexing),
        ('/tasks/mailchimp', MailchimpAdd)],
        debug=True)
 app = appengine_config.recording_add_wsgi_middleware(app)


### PR DESCRIPTION
The immediate indexing did not get the right team_key in the search
document because the data hadn't setttled. This delayed indexing by 5
seconds.
