### PR TITLE
Reduced size of contacts_json and created contact.info API call

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: ghidonations
-version: 5p
+version: 5q
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/endpoints_messages.py
+++ b/endpoints_messages.py
@@ -272,6 +272,13 @@ class ConfirmationAnnualReport_In(messages.Message):
     contact_key = messages.StringField(1, required=True)
     year = messages.IntegerField(2, required=True)
 
+# contact.info
+class Contact_Info(messages.Message):
+    key = messages.StringField(1, required=True)
+    name = messages.StringField(2, required=True)
+    email = messages.StringField(3, repeated=True)
+    address = messages.StringField(4, repeated=True)
+
 # spreadsheet.start
 class SpreadsheetStart_In(messages.Message):
     mode = messages.StringField(1, required=True)

--- a/ghiendpoints.py
+++ b/ghiendpoints.py
@@ -707,6 +707,16 @@ class EndpointsAPI(remote.Service):
 
         return SuccessMessage_Out(success=success, message=message)
 
+    # contact.info
+    @endpoints.method(ContactKey_In, Contact_Info, path='contact/info',
+                    http_method='POST', name='contact.info')
+    def contact_info(self, req):
+        isAdmin, s = tools.checkAuthentication(self, True, from_endpoints=True)
+        c = tools.getKey(req.contact_key).get()
+
+        return Contact_Info(key=c.websafe, name=c.name, email=c.email,
+                            address=c.address)
+
     # team.delete
     @endpoints.method(TeamKey_In, SuccessMessage_Out, path='team/delete',
                     http_method='POST', name='team.delete')

--- a/js/donor_report_select.js
+++ b/js/donor_report_select.js
@@ -12,7 +12,13 @@ $(document).ready(function(){
             select: function(e, ui){
                 $("input[name=contact]").val(ui.item.name)
                 contact = ui.item.key
-                contact_email = ui.item.email
+
+                var params2 = {'contact_key':contact}
+                var request2 = ghiapi.contact.info(params2)
+
+                request2.execute(function(response2) {
+                    contact_email = response2.email[0]
+                })
             }
         });
     })

--- a/js/offline.js
+++ b/js/offline.js
@@ -14,18 +14,23 @@ $(document).ready(function(){
             $("input[name=name]").autocomplete({
                 source: JSON.parse(response.json_data),
                 select: function(event, ui){
-                    $("input[name=email]").val(ui.item.email[0])
+                    var params2 = {'contact_key':ui.item.key}
+                    var request2 = ghiapi.contact.info(params2)
 
-                    try{
-                        var address = JSON.parse(ui.item.address)
-                        $("input[name=street]").val(address[0])
-                        $("input[name=city]").val(address[1])
-                        $("input[name=state]").val(address[2])
-                        $("input[name=zip]").val(address[3])
-                    }
-                    catch(err) {
-                        void(0)
-                    }
+                    request2.execute(function(response2){
+                        $("input[name=email]").val(response2.email[0])
+
+                        try{
+                            $("input[name=street]").val(response2.address[0])
+                            $("input[name=city]").val(response2.address[1])
+                            $("input[name=state]").val(response2.address[2])
+                            $("input[name=zip]").val(response2.address[3])
+                        }
+                        catch(err) {
+                            void(0)
+                        }
+                    })
+
                 }
             });
         })

--- a/tasks.py
+++ b/tasks.py
@@ -261,8 +261,6 @@ class UpdateContactsJSON(webapp2.RequestHandler):
         for c in s.data.all_contacts:
             contact = {}
             contact["label"] = c.name
-            contact["email"] = c.email
-            contact["address"] = json.dumps(c.address)
             contact["key"] = str(c.websafe)
             
             contacts.append(contact)


### PR DESCRIPTION
CRITICAL - contacts_json is over 1 MB and the endpoints request is failing.

Just include key and name in contacts_json and create a new API call contact_info to get address/email info. Will do good things for performance as welll.
