### PR TITLE
Secure donate page

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: ghidonations
-version: 5q
+version: 5r
 runtime: python27
 api_version: 1
 threadsafe: true
@@ -59,7 +59,7 @@ handlers:
 
 - url: /donate
   script: mooha.app
-  secure: optional
+  secure: always
 
 - url: /logout
   script: mooha.app


### PR DESCRIPTION
There was an issue with same origin policy when the donate page was
serve insecurely. This change ensures that it is secure.